### PR TITLE
Feat: update cdn & origin A record

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ Cloudflare Partner Management Panel
 ## 功能
 * CNAME接入
 * reCAPTCHA
-* 设置回源地址为IP（基于xip.io）（默认关闭此功能）
+* 设置回源地址为IP（基于sslip.io）（默认关闭此功能）
 
 可用示例：[https://cf.131.re/](https://cf.131.re/)

--- a/cf.class.php
+++ b/cf.class.php
@@ -77,12 +77,12 @@ class CF {
         $at=$record["@"];
         unset($record["@"]);
         if ((Enable_A_Record) && (filter_var($at,FILTER_VALIDATE_IP,FILTER_FLAG_IPV4))){
-            $at=$at.'.xip.io';
+            $at=$at.'.sslip.io';
         }
         $str="";
         foreach ($record as $key => $value){
             if ((Enable_A_Record) && (filter_var($value,FILTER_VALIDATE_IP,FILTER_FLAG_IPV4))){
-                $str.=$key.":".$value.".xip.io,";
+                $str.=$key.":".$value.".sslip.io,";
             }else{
                 $str.=$key.":".$value.",";
             }

--- a/config.php
+++ b/config.php
@@ -11,5 +11,5 @@ define("Enable_reCAPTCHA",false);
 define("reCAPTCHA_Site","");
 define("reCAPTCHA_Secret","");
 
-//A记录解析（基于xip.io）
+//A记录解析（基于sslip.io）
 define("Enable_A_Record",false);

--- a/header.php
+++ b/header.php
@@ -12,8 +12,8 @@
     <meta name="description" itemprop="description" property="og:description" content="CNAME接入Cloudflare" />
     <meta name="description" content="<?php echo SITE_NAME;?> - Cloudflare Partners, CNAME接入Cloudflare" />
     <meta name="keywords" content="<?php echo SITE_NAME;?>,cloudflare,partner,partners,cname" />
-    <link rel="stylesheet" href="https://cdnjs.loli.net/ajax/libs/mdui/0.4.0/css/mdui.min.css" />
-    <script src="https://cdnjs.loli.net/ajax/libs/mdui/0.4.0/js/mdui.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/mdui@0.4.0/dist/css/mdui.min.css" />
+    <script src="https://cdn.jsdelivr.net/npm/mdui@0.4.0/dist/js/mdui.min.js"></script>
     <script src="https://www.recaptcha.net/recaptcha/api.js" async defer></script>
 </head>
 

--- a/manage_domain.php
+++ b/manage_domain.php
@@ -79,8 +79,8 @@ include_once("header.php");
                         {
                           $is_ssl=true;
                         }
-                        if ((Enable_A_Record) && (filter_var(str_replace('.xip.io','',$set),FILTER_VALIDATE_IP,FILTER_FLAG_IPV4))){
-                          $set=str_replace('.xip.io','',$set);
+                        if ((Enable_A_Record) && (filter_var(str_replace('.sslip.io','',$set),FILTER_VALIDATE_IP,FILTER_FLAG_IPV4))){
+                          $set=str_replace('.sslip.io','',$set);
                         }
                         echo "<tr>".
                         '<td><button style="display:inline;" class="mdui-btn mdui-btn-icon mdui-shadow-3 ';


### PR DESCRIPTION
Use jsDelivr to load `mdui`, as `loli.net` has lost its ICP license and been slowed down.
Use `sslip.io` in replace of `xip.io`, because `sslip.io`'s ADNS is much faster.